### PR TITLE
KDT3RDPROJ-33/Spring/메인페이지 완성 및 헤더

### DIFF
--- a/src/main/java/com/mingle/controllers/PartyController.java
+++ b/src/main/java/com/mingle/controllers/PartyController.java
@@ -111,6 +111,13 @@ public class PartyController {
 		return ResponseEntity.ok().build();
 	}
 	
+	// 메인에서 사용할 전체 서비스 리스트
+	@GetMapping("/getServiceMainPage")
+	public ResponseEntity<List<ServiceDTO>> getServiceMainPage() {
+		List<ServiceDTO> list = pServ.selectServiceByCategoryId("전체");
+		return ResponseEntity.ok(list);
+	} 
+	
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<String> exceptionHandler(Exception e) {
 		e.printStackTrace();

--- a/src/main/java/com/mingle/controllers/PartyController.java
+++ b/src/main/java/com/mingle/controllers/PartyController.java
@@ -113,9 +113,19 @@ public class PartyController {
 	
 	// 메인에서 사용할 전체 서비스 리스트
 	@GetMapping("/getServiceMainPage")
-	public ResponseEntity<List<ServiceDTO>> getServiceMainPage() {
+	public ResponseEntity<Map<String, Object>> getServiceMainPage(Authentication authentication) {
 		List<ServiceDTO> list = pServ.selectServiceByCategoryId("전체");
-		return ResponseEntity.ok(list);
+		
+		// 로그인한 사용자일 경우 가입한 목록 가져오기
+		List<Integer> joinList = new ArrayList<>();
+		if(authentication != null) {
+			joinList = pServ.selectServiceByIsJoin("전체", authentication.getName());
+		}
+		Map<String, Object> param = new HashMap<>();
+		param.put("list", list);
+		param.put("joinList", joinList);
+		return ResponseEntity.ok(param);
+//		return ResponseEntity.ok(list);
 	} 
 	
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/mingle/controllers/PartyController.java
+++ b/src/main/java/com/mingle/controllers/PartyController.java
@@ -136,8 +136,13 @@ public class PartyController {
 	@GetMapping("/getPartyListForMain")
 	public ResponseEntity<List<PartyInformationForMainDTO>> selectPartyListForMain(@RequestParam Instant start, @RequestParam Instant end) {
 		List<PartyInformationForMainDTO> list = pServ.selectPartyListForMain(start, end);
-		System.out.println(list);
 		return ResponseEntity.ok(list);
+	}
+	
+	// 메인페이지 모집중인 파티 개수
+	@GetMapping("/selectAllPartyCountForMain")
+	public ResponseEntity<Integer> selectAllPartyCountForMain(){
+		return ResponseEntity.ok(pServ.selectAllPartyCountForMain());
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/mingle/controllers/PartyController.java
+++ b/src/main/java/com/mingle/controllers/PartyController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mingle.dto.PartyInformationDTO;
+import com.mingle.dto.PartyInformationForMainDTO;
 import com.mingle.dto.PaymentDTO;
 import com.mingle.dto.ServiceCategoryDTO;
 import com.mingle.dto.ServiceDTO;
@@ -28,10 +29,10 @@ import com.mingle.services.PartyService;
 @RestController
 @RequestMapping("/api/party")
 public class PartyController {
-	
+
 	@Autowired
-	private PartyService pServ ;
-	
+	private PartyService pServ;
+
 	// 제공하는 서비스 카테고리명 불러오기
 	@GetMapping
 	public ResponseEntity<List<ServiceCategoryDTO>> selectCategoryAll() {
@@ -45,15 +46,16 @@ public class PartyController {
 //		List<ServiceDTO> list = pServ.selectServiceByCategoryId(id);
 //		return ResponseEntity.ok(list);
 //	}
-	
+
 	// 카테고리별 서비스 정보 & 가입한 서비스 정보 불러오기
 	@GetMapping("/getService/{id}")
-	public ResponseEntity<Map<String, Object>> selectServiceByCategoryId(@PathVariable String id, Authentication authentication) {
+	public ResponseEntity<Map<String, Object>> selectServiceByCategoryId(@PathVariable String id,
+			Authentication authentication) {
 		List<ServiceDTO> list = pServ.selectServiceByCategoryId(id);
-		
+
 		// 로그인한 사용자일 경우 가입한 목록 가져오기
 		List<Integer> joinList = new ArrayList<>();
-		if(authentication != null) {
+		if (authentication != null) {
 			joinList = pServ.selectServiceByIsJoin(id, authentication.getName());
 		}
 		Map<String, Object> param = new HashMap<>();
@@ -61,21 +63,21 @@ public class PartyController {
 		param.put("joinList", joinList);
 		return ResponseEntity.ok(param);
 	}
-	
+
 	// 특정 서비스 정보 불러오기
 	@GetMapping("/getServiceById/{id}")
 	public ResponseEntity<ServiceDTO> selectServiceByServiceId(@PathVariable Long id) {
 		ServiceDTO dto = pServ.selectServiceByServiceId(id);
 		return ResponseEntity.ok(dto);
 	}
-	
+
 	// 파티 정보 저장, 파티 등록, 파티장 등록
 	@PostMapping("/auth")
-	public ResponseEntity<Void> inertParty (@RequestBody PartyInformationDTO partyData, Authentication authentication){
+	public ResponseEntity<Void> inertParty(@RequestBody PartyInformationDTO partyData, Authentication authentication) {
 		pServ.inertParty(partyData, authentication.getName());
 		return ResponseEntity.ok().build();
 	}
-		
+
 //	// 가입한 파티 목록 불러오기
 //	@GetMapping("/getMyPartyList")
 //	public ResponseEntity<List<PartyInformationDTO>> getMypartyList(Authentication authentication){
@@ -85,49 +87,59 @@ public class PartyController {
 
 	// 생성된 파티 목록 불러오기
 	@GetMapping("/getPartyList/{id}")
-	public ResponseEntity<List<PartyInformationDTO>> getPartyList(@PathVariable Long id){
+	public ResponseEntity<List<PartyInformationDTO>> getPartyList(@PathVariable Long id) {
 		List<PartyInformationDTO> list = pServ.selectPartyList(id);
 		return ResponseEntity.ok(list);
 	}
-	
+
 	// 등록된 파티 정보 중 선택한 날짜에 해당하는 파티 정보 불러오기
 	@GetMapping("/getPartyListByStartDate/{id}")
-	public ResponseEntity<List<PartyInformationDTO>> selectPartyListByStartDate(@PathVariable Long id, @RequestParam Instant start, @RequestParam Instant end){
+	public ResponseEntity<List<PartyInformationDTO>> selectPartyListByStartDate(@PathVariable Long id,
+			@RequestParam Instant start, @RequestParam Instant end) {
 		List<PartyInformationDTO> list = pServ.selectPartyListByStartDate(id, start, end);
 		return ResponseEntity.ok(list);
 	}
-	
+
 	// 서비스 명 리스트 불러오기
 	@GetMapping("/getServiceNameList")
-	public ResponseEntity<List<ServiceDTO>> getServiceNameList(){
+	public ResponseEntity<List<ServiceDTO>> getServiceNameList() {
 		List<ServiceDTO> dtos = pServ.getServiceNameList();
 		return ResponseEntity.ok(dtos);
 	}
 
-	// 파티 가입 & 첫 달 결제 내역 저장  & 밍글 머니 사용
+	// 파티 가입 & 첫 달 결제 내역 저장 & 밍글 머니 사용
 	@PostMapping("/auth/joinParty/{id}")
-	public ResponseEntity<Void> joinParty(@PathVariable Long id, @RequestBody(required = false) PaymentDTO paymentData, Authentication authentication){
+	public ResponseEntity<Void> joinParty(@PathVariable Long id, @RequestBody(required = false) PaymentDTO paymentData,
+			Authentication authentication) {
 		pServ.insertJoinParty(id, authentication.getName(), paymentData);
 		return ResponseEntity.ok().build();
 	}
-	
-	// 메인에서 사용할 전체 서비스 리스트
-	@GetMapping("/getServiceMainPage")
-	public ResponseEntity<Map<String, Object>> getServiceMainPage(Authentication authentication) {
-		List<ServiceDTO> list = pServ.selectServiceByCategoryId("전체");
-		
-		// 로그인한 사용자일 경우 가입한 목록 가져오기
-		List<Integer> joinList = new ArrayList<>();
-		if(authentication != null) {
-			joinList = pServ.selectServiceByIsJoin("전체", authentication.getName());
-		}
-		Map<String, Object> param = new HashMap<>();
-		param.put("list", list);
-		param.put("joinList", joinList);
-		return ResponseEntity.ok(param);
-//		return ResponseEntity.ok(list);
-	} 
-	
+
+//	// 메인 페이지에 출력할
+//	// 카테고리별 서비스 정보 & 가입한 서비스 정보 불러오기
+//	@GetMapping("/getService/{id}")
+//	public ResponseEntity<Map<String, Object>> selectServiceByCategoryId(Authentication authentication) {
+//		List<ServiceDTO> list = pServ.selectServiceByCategoryId("전");
+//
+//		// 로그인한 사용자일 경우 가입한 목록 가져오기
+//		List<Integer> joinList = new ArrayList<>();
+//		if (authentication != null) {
+//			joinList = pServ.selectServiceByIsJoin(id, authentication.getName());
+//		}
+//		Map<String, Object> param = new HashMap<>();
+//		param.put("list", list);
+//		param.put("joinList", joinList);
+//		return ResponseEntity.ok(param);
+//	}
+
+	// 메인페이지에 출력할 파티 정보 불러오기
+	@GetMapping("/getPartyListForMain")
+	public ResponseEntity<List<PartyInformationForMainDTO>> selectPartyListForMain(@RequestParam Instant start, @RequestParam Instant end) {
+		List<PartyInformationForMainDTO> list = pServ.selectPartyListForMain(start, end);
+		System.out.println(list);
+		return ResponseEntity.ok(list);
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<String> exceptionHandler(Exception e) {
 		e.printStackTrace();

--- a/src/main/java/com/mingle/domain/entites/PartyInformationForMain.java
+++ b/src/main/java/com/mingle/domain/entites/PartyInformationForMain.java
@@ -1,0 +1,47 @@
+package com.mingle.domain.entites;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class PartyInformationForMain {
+	@Id
+	@Column(name="id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+	@Column(name="service_id")
+	private long serviceId;
+	@Column(name="people_count")
+	private long peopleCount;
+	@Column(name="start_date")
+	private Instant startDate;
+	@Column(name="month_count")
+	private long monthCount;
+	@Column(name="calculation_date")
+	private String calculationDate;
+	@Column(name="login_id")
+	private String loginId;
+	@Column(name="login_pw")
+	private String loginPw;
+	@Column(name="price")
+	private Long price;
+	@Column(name="max_people_count")
+	private Long maxPeopleCount;
+	@Column(name="english_name")
+	private String englishName;
+}

--- a/src/main/java/com/mingle/domain/repositories/PartyInformationForMainRepository.java
+++ b/src/main/java/com/mingle/domain/repositories/PartyInformationForMainRepository.java
@@ -1,0 +1,17 @@
+package com.mingle.domain.repositories;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mingle.domain.entites.PartyInformation;
+import com.mingle.domain.entites.PartyInformationForMain;
+
+
+public interface PartyInformationForMainRepository extends JpaRepository<PartyInformationForMain, Long>{
+	@Query(value="select current_party_info.*,service.price as price, service.max_people_count, service.english_name from current_party_info join service on current_party_info.service_id=service.id  WHERE start_date >= :start and start_date <= :end order by start_date, current_party_info.id desc limit 12;" , nativeQuery = true)
+	List<PartyInformationForMain> findPartyInfoForMain(@Param("start") Instant start, @Param("end") Instant end);
+}

--- a/src/main/java/com/mingle/domain/repositories/PartyInformationRepository.java
+++ b/src/main/java/com/mingle/domain/repositories/PartyInformationRepository.java
@@ -19,5 +19,7 @@ public interface PartyInformationRepository extends JpaRepository<PartyInformati
 	
 	@Query(value = "select * from current_party_info WHERE service_id = :serviceId and start_date >= :start and start_date <= :end order by start_date, id desc", nativeQuery = true)
 	List<PartyInformation> findPartyInformationByServiceIdAndCountAndStartDate(@Param("serviceId") Long serviceId, @Param("start") Instant start, @Param("end") Instant end);
-
+	
+	@Query(value = "select * from current_party_info", nativeQuery = true)
+	List<PartyInformation> selectAllParty();
 }

--- a/src/main/java/com/mingle/dto/PartyInformationForMainDTO.java
+++ b/src/main/java/com/mingle/dto/PartyInformationForMainDTO.java
@@ -1,0 +1,28 @@
+package com.mingle.dto;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class PartyInformationForMainDTO {
+	private long id;
+	private long serviceId;
+	private long peopleCount;
+	private Instant startDate;
+	private long monthCount;
+	private long calculationDate;
+	private String loginId;
+	private String loginPw;
+	private Long price;
+	private Long maxPeopleCount;
+	private String englishName;
+}

--- a/src/main/java/com/mingle/mappers/PartyInformationForMainMapper.java
+++ b/src/main/java/com/mingle/mappers/PartyInformationForMainMapper.java
@@ -1,0 +1,13 @@
+package com.mingle.mappers;
+
+import org.mapstruct.Mapper;
+
+import com.mingle.domain.entites.PartyInformationForMain;
+import com.mingle.domain.entites.PartyInformation;
+import com.mingle.dto.PartyInformationForMainDTO;
+import com.mingle.dto.PartyInformationDTO;
+
+@Mapper(componentModel = "spring")
+public interface PartyInformationForMainMapper extends GenericMapper<PartyInformationForMainDTO, PartyInformationForMain>{
+
+}

--- a/src/main/java/com/mingle/services/PartyService.java
+++ b/src/main/java/com/mingle/services/PartyService.java
@@ -13,6 +13,7 @@ import com.mingle.domain.entites.Member;
 import com.mingle.domain.entites.PartyMember;
 import com.mingle.domain.entites.PartyRegistration;
 import com.mingle.domain.repositories.MemberRepository;
+import com.mingle.domain.repositories.PartyInformationForMainRepository;
 import com.mingle.domain.repositories.PartyInformationRepository;
 import com.mingle.domain.repositories.PartyMemberRepository;
 import com.mingle.domain.repositories.PartyRegistrationRepository;
@@ -20,9 +21,11 @@ import com.mingle.domain.repositories.PaymentRepository;
 import com.mingle.domain.repositories.ServiceCategoryRepository;
 import com.mingle.domain.repositories.ServiceRepository;
 import com.mingle.dto.PartyInformationDTO;
+import com.mingle.dto.PartyInformationForMainDTO;
 import com.mingle.dto.PaymentDTO;
 import com.mingle.dto.ServiceCategoryDTO;
 import com.mingle.dto.ServiceDTO;
+import com.mingle.mappers.PartyInformationForMainMapper;
 import com.mingle.mappers.PartyInformationMapper;
 import com.mingle.mappers.PaymentMapper;
 import com.mingle.mappers.ServiceCategoryMapper;
@@ -58,6 +61,12 @@ public class PartyService {
 	// 파티장 등록
 	@Autowired
 	private PartyMemberRepository pmRepo;
+	
+	// 파티 정보 메인 페이지
+	@Autowired
+	private PartyInformationForMainRepository pimRepo;
+	@Autowired
+	private PartyInformationForMainMapper pimMap;
 	
 	// 첫 달 결제 정보 저장을 위한 paymentRepo, mapper
 	@Autowired
@@ -174,5 +183,11 @@ public class PartyService {
 	public boolean isMemberParty(String userId) {
 		
 		return pmRepo.isAlreadyMember(userId);
+	}
+	
+	// 메인페이지에 출력할 파티 정보 불러오기
+	public List<PartyInformationForMainDTO> selectPartyListForMain(Instant start, Instant end){
+//		return pimMap.toDtoList(pimRepo.findPartyInfoForMain(start, end));
+		return pimMap.toDtoList(pimRepo.findPartyInfoForMain(start, end));
 	}
 }

--- a/src/main/java/com/mingle/services/PartyService.java
+++ b/src/main/java/com/mingle/services/PartyService.java
@@ -186,8 +186,12 @@ public class PartyService {
 	}
 	
 	// 메인페이지에 출력할 파티 정보 불러오기
-	public List<PartyInformationForMainDTO> selectPartyListForMain(Instant start, Instant end){
-//		return pimMap.toDtoList(pimRepo.findPartyInfoForMain(start, end));
+	public List<PartyInformationForMainDTO> selectPartyListForMain(Instant start, Instant end){	
 		return pimMap.toDtoList(pimRepo.findPartyInfoForMain(start, end));
+	}
+	
+	// 메인페이지 모집중인 파티 개수
+	public int selectAllPartyCountForMain() {
+		return piRepo.selectAllParty().size();
 	}
 }


### PR DESCRIPTION
- 수정 요청사항 변경
- 메인페이지에서 불러올 파티 정보 가져오기

1. PartyController
- 메인 페이지에서 출력할 파티 정보 가져오기
- 메인 페이지 모집중인 파티 개수 가져오기

2. PartyInfomationForMain
- 메인에서는 서비스 별로 가져오는 것이 아니라 전체에 대한 정보에 가격, 최대인원, 영어 이름등이 필요하다고 생각해서 가져오는 entity 생성 -> 해당 부분은 원래 참여 가능한 파티에 대해서 참여도 처리하려고 해서 이렇게 불러왔는데 현재는 기본 속성에 영어이름만 추가적으로 사용중

3. PartyInformationForMainRepository
- current_party_info 뷰에 추가로 가격, 최대인원, 영어이름 가져오기

4. PartyInfomationRepository
- 모든 파티 개수를 불러오기 위한 코드 작성

5. PartyInformationForMainDTO
- 메인에서는 서비스 별로 가져오는 것이 아니라 전체에 대한 정보에 가격, 최대인원, 영어 이름등이 필요하다고 생각해서 가져오는 DTO생성 -> 해당 부분은 원래 참여 가능한 파티에 대해서 참여도 처리하려고 해서 이렇게 불러왔는데 현재는 기본 속성에 영어이름만 추가적으로 사용중

6. PartyInformationForMainMapper
- PartyInfomationForMain과 PartyInformationForMainDTO형변환을 위한 매퍼

7. MemberService
- 현재 시간을 변환해서 삽입하던 내용 삭제
- birth를 -9시간 조정해서 삽입하도록 변경

8. PartyService
- 메인페이지에 사용되는 파티 정보를 가져올 수 있는 repo와 mapper 생성
- 메인페이지에 출력할 파티 정보 및 모집중인 총 파티 개수 가져오기
